### PR TITLE
fix: use correct MIME type for SVG and JPG images

### DIFF
--- a/src/app/components/player-toolbar/player-toolbar.component.ts
+++ b/src/app/components/player-toolbar/player-toolbar.component.ts
@@ -4,6 +4,7 @@ import { Observable, Subscription, tap, firstValueFrom } from 'rxjs'; // firstVa
 import { Group, Stream, ServerDetail, Client, SnapCastServerStatusResponse } from 'src/app/model/snapcast.model'; // Client importiert für Typisierung
 import { SnapcastService } from 'src/app/services/snapcast.service';
 import { Haptics, ImpactStyle, NotificationType } from '@capacitor/haptics';
+import { toImageDataUrl } from 'src/app/utils/image.utils';
 
 
 @Component({
@@ -130,13 +131,7 @@ export class PlayerToolbarComponent implements OnInit, OnChanges, OnDestroy {
   }
 
 
-  convertCoverDataBase64(coverData: string, extension: string): string {
-    if (!coverData) {
-      return '';
-    }
-    // Convert base64 data to a data URL
-    return `data:image/${extension};base64,${coverData}`;
-  }
+  convertCoverDataBase64 = toImageDataUrl;
 
   knobMoveStartEvent(event: any): void {
     console.log('Knob move started:', event);

--- a/src/app/components/snapcast-group-preview/snapcast-group-preview.component.ts
+++ b/src/app/components/snapcast-group-preview/snapcast-group-preview.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Group, Stream } from 'src/app/model/snapcast.model';
 import { Speaker } from 'src/app/model/speaker.model';
+import { toImageDataUrl } from 'src/app/utils/image.utils';
 
 @Component({
   selector: 'app-snapcast-group-preview',
@@ -64,13 +65,7 @@ export class SnapcastGroupPreviewComponent  implements OnInit, OnChanges {
     }
   }
 
-  convertCoverDataBase64(coverData: string, extension: string): string {
-    if (!coverData) {
-      return '';
-    }
-    // Convert base64 data to a data URL
-    return `data:image/${extension};base64,${coverData}`;
-  }
+  convertCoverDataBase64 = toImageDataUrl;
 
   getActiveSpeaker(): Speaker | undefined {
     if (!this.group || !this.speakerData) {

--- a/src/app/components/snapcast-stream-preview/snapcast-stream-preview.component.ts
+++ b/src/app/components/snapcast-stream-preview/snapcast-stream-preview.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Stream } from 'src/app/model/snapcast.model';
+import { toImageDataUrl } from 'src/app/utils/image.utils';
 
 @Component({
   selector: 'app-snapcast-stream-preview',
@@ -15,12 +16,6 @@ export class SnapcastStreamPreviewComponent  implements OnInit {
   ngOnInit() {}
 
   
-  convertCoverDataBase64(coverData: string, extension: string): string {
-    if (!coverData) {
-      return '';
-    }
-    // Convert base64 data to a data URL
-    return `data:image/${extension};base64,${coverData}`;
-  }
+  convertCoverDataBase64 = toImageDataUrl;
 
 }

--- a/src/app/pages/streams/streams.page.ts
+++ b/src/app/pages/streams/streams.page.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 import { SnapcastWebsocketNotification } from 'src/app/model/snapcast-websocket-notification.model';
 import { SnapCastServerStatusResponse } from 'src/app/model/snapcast.model';
 import { SnapcastService } from 'src/app/services/snapcast.service';
+import { toImageDataUrl } from 'src/app/utils/image.utils';
 
 @Component({
   selector: 'app-streams',
@@ -21,8 +22,6 @@ export class StreamsPage implements OnInit {
     this.displayState = this.snapcastService.state$
   }
 
-  convertBase64ToImage(base64String: string, format: string): string {
-    return `data:image/${format};base64,${base64String}`;
-  }
+  convertBase64ToImage = toImageDataUrl;
 
 }

--- a/src/app/utils/image.utils.ts
+++ b/src/app/utils/image.utils.ts
@@ -1,0 +1,12 @@
+const MIME_TYPES: Record<string, string> = {
+  'svg': 'svg+xml',
+  'jpg': 'jpeg',
+};
+
+export function toImageDataUrl(base64Data: string, extension: string): string {
+  if (!base64Data) {
+    return '';
+  }
+  const mimeType = MIME_TYPES[extension.toLowerCase()] ?? extension;
+  return `data:image/${mimeType};base64,${base64Data}`;
+}


### PR DESCRIPTION
I noticed SVG images were not working (showing a broken image icon) in the album cover images:
<img width="500" height="634" alt="Screenshot 2026-01-24 at 17 08 55" src="https://github.com/user-attachments/assets/e32c5268-b8ba-4540-9e51-1354a6c2b4a8" />

Created a simple toImageDataUrl function that takes base64 data and an extension, and returns correctly MIME'd url data:
<img width="491" height="631" alt="Screenshot 2026-01-24 at 17 08 07" src="https://github.com/user-attachments/assets/45dd1e25-12cc-4e1a-8de5-0c7b8af838f2" />

Most extensions will stay the same, except for;
- svg → image/svg+xml
- jpg → image/jpeg

Note; I haven't tested JPEG, since I don't have any streams that return a JPEG images. But `image/jpeg` is the official MIME type of JPEG images.
Note 2; not sure why my Spotify stream always returns the logo instead of album cover, but that's probably an issue in the stream.

_Tested by human._